### PR TITLE
_makeErrorObject: construct the proper error response from the error …

### DIFF
--- a/MoleClient.js
+++ b/MoleClient.js
@@ -183,10 +183,26 @@ class MoleClient {
 
     _makeErrorObject(errorData) {
         const errorBuilder = {
+            [errorCodes.PARSE_ERROR]: () => {
+                return new X.ParseError();
+            },
+            [errorCodes.INVALID_REQUEST]: () => {
+                return new X.InvalidRequest();
+            },
             [errorCodes.METHOD_NOT_FOUND]: () => {
                 return new X.MethodNotFound();
+            },
+            [errorCodes.INVALID_PARAMS]: () => {
+                return new X.InvalidParams();
+            },
+            [errorCodes.INTERNAL_ERROR]: () => {
+                return new X.InternalError();
             }
         }[errorData.code];
+
+        if (!errorBuilder) {
+                return new X.ServerError(errorData);
+        }
 
         return errorBuilder();
     }


### PR DESCRIPTION
Hi
This should return the proper error status code.
can you double check this (I'm no node expert at all)
Also is possible to not overwrite the data but pass the original one?

This is for handling error different from the default one
```
'{"jsonrpc": "2.0", "error": {"code": -32000, "message": "Server error", "data": "ValueError: foo"}, "id": 1}'
```
Signed-off-by: Nicola Lunghi <25422924+nicola-lunghi@users.noreply.github.com>