### PR TITLE
Cancel timer when server responds

### DIFF
--- a/MoleClient.js
+++ b/MoleClient.js
@@ -62,15 +62,15 @@ class MoleClient {
         const data = JSON.stringify(object);
 
         return new Promise((resolve, reject) => {
-            this.pendingRequest[id] = { resolve, reject, sentObject: object };
-
-            setTimeout(() => {
+            const timer = setTimeout(() => {
                 if (this.pendingRequest[id]) {
                     delete this.pendingRequest[id];
 
                     reject(new X.RequestTimout());
                 }
             }, this.requestTimeout);
+
+            this.pendingRequest[id] = { resolve, reject, sentObject: object, timer };
 
             return this.transport.sendData(data).catch(error => {
                 delete this.pendingRequest[id];
@@ -99,6 +99,7 @@ class MoleClient {
         delete this.pendingRequest[response.id];
 
         if (!resolvers) return;
+        clearTimeout(resolvers.timer);
 
         if (isSuccessfulResponse) {
             resolvers.resolve(response.result);
@@ -127,8 +128,9 @@ class MoleClient {
 
         if (!this.pendingRequest[batchId]) return;
 
-        const { sentObject, resolve } = this.pendingRequest[batchId];
+        const { sentObject, resolve, timer } = this.pendingRequest[batchId];
         delete this.pendingRequest[batchId];
+        clearTimeout(timer);
 
         const batchResults = [];
         let errorIdx = 0;


### PR DESCRIPTION
The code has a bug: the program below does not terminate right away after all requests have been processed, but has to wait for the 300-second timeout.
This patch fixes the bug by canceling the timer when server responds.

```js
const MoleClient = require('../MoleClient');
const MoleServer = require('../MoleServer');

const TransportClient = require('./TransportClient');
const TransportServer = require('./TransportServer');

const EventEmitter = require('events');

(async () => {
    const emitter = new EventEmitter();
    const server = new MoleServer({
      transports: [new TransportServer({ emitter, inTopic: 'c', outTopic: 's' })],
    });
    server.expose({ f: () => 1 });
    await server.run();

    const client = new MoleClient({
      requestTimeout: 300000,
      transport: new TransportClient({ emitter, inTopic: 's', outTopic: 'c' }),
    });
    await client.callMethod('f', []);
    await client.runBatch([
      ['f', [1]],
    ]);
    console.log('program should exit now');
})();

```