### PR TITLE
Allow request id to be zero

### DIFF
--- a/MoleServer.js
+++ b/MoleServer.js
@@ -69,7 +69,7 @@ class MoleServer {
             try {
                 const result = await this.methods[methodName].apply(this.methods, params);
 
-                if (!id) return; // For notifications do not respond. "" means send nothing
+                if (id !==0 && !id) return; // For notifications do not respond. "" means send nothing
 
                 return {
                     jsonrpc: '2.0',


### PR DESCRIPTION
With the current implementation, sending a request with `0` as a request `id`  will not send any response, despite being a valid id (often used as a default value in testing).
This change allows the id to be 0, as the JSON-RPC specification doesn't forbid it.

> An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]
The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
> 
> [1] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
> 
> [2] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.

https://www.jsonrpc.org/specification#request_object