### PR TITLE
Implement ping/pong mechanism to check server availability

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -3,6 +3,9 @@
 class EventEmitter {
     constructor() {
         this._listeners = {};
+
+        // Used for test purposes
+        this._paused = false;
     }
 
     on(eventName, listener) {
@@ -26,6 +29,10 @@ class EventEmitter {
     }
 
     emit(eventName, ...args) {
+        if (this._paused) {
+            return false;
+        }
+
         const listeners = this._listeners[eventName];
 
         if (!listeners) {
@@ -41,6 +48,14 @@ class EventEmitter {
         }
 
         return true;
+    }
+
+    pause() {
+        this._paused = true;
+    }
+
+    resume() {
+        this._paused = false;
     }
 }
 

--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -1,0 +1,47 @@
+// Use custom class because we don't have EventEmitter in browser
+
+class EventEmitter {
+    constructor() {
+        this._listeners = {};
+    }
+
+    on(eventName, listener) {
+        if (!this._listeners[eventName]) {
+            this._listeners[eventName] = [];
+        }
+
+        this._listeners[eventName].push(listener);
+
+        return this;
+    }
+
+    off(eventName, listener) {
+        if (!this._listeners[eventName]) {
+            return this;
+        }
+
+        this._listeners[eventName] = this._listeners[eventName].filter(item => item !== listener);
+
+        return this;
+    }
+
+    emit(eventName, ...args) {
+        const listeners = this._listeners[eventName];
+
+        if (!listeners) {
+            return false;
+        }
+
+        for (const listener of listeners) {
+            try {
+               listener(...args);
+            } catch (error) {
+                // Ignore errors
+            }
+        }
+
+        return true;
+    }
+}
+
+module.exports = EventEmitter;

--- a/MoleClient.js
+++ b/MoleClient.js
@@ -25,7 +25,21 @@ class MoleClient {
         this.eventEmitter = new EventEmitter();
 
         if (ping) {
-            this._setupPingPong();
+            this.pingIntervalId = this._setupPingPong();
+        }
+    }
+
+    async init() {
+        // It is not required to call this method manually,
+        // but it could be useful in case when we want to
+        // establish connection before callMethod
+        await this._init();
+    }
+
+    shutdown() {
+        if (this.pingIntervalId) {
+            clearInterval(this.pingIntervalId);
+            this.pingIntervalId = null;
         }
     }
 
@@ -118,6 +132,8 @@ class MoleClient {
                 }
             }
         }, this.pingInterval);
+
+        return intervalId;
     }
 
     _sendRequest({ object, id, timeout = this.requestTimeout }) {

--- a/MoleServer.js
+++ b/MoleServer.js
@@ -29,7 +29,14 @@ class MoleServer {
     }
 
     async _processRequest(transport, data) {
-        const requestData = JSON.parse(data);
+        let requestData;
+
+        try {
+            requestData = JSON.parse(data);
+        } catch (error) {
+            // Handle cases when server receives broken JSON
+            return;
+        }
 
         const isRequest = requestData.hasOwnProperty('method')
             || (Array.isArray(requestData)

--- a/constants.js
+++ b/constants.js
@@ -2,6 +2,12 @@ const INTERNAL_METHODS = {
     PING: '__ping__'
 };
 
+const CLIENT_EVENTS = {
+    SERVER_AVAILABLE: 'server_available',
+    SERVER_UNAVAILABLE: 'server_unavailable'
+};
+
 module.exports = {
-    INTERNAL_METHODS
+    INTERNAL_METHODS,
+    CLIENT_EVENTS
 };

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,7 @@
+const INTERNAL_METHODS = {
+    PING: '__ping__'
+};
+
+module.exports = {
+    INTERNAL_METHODS
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mole-rpc",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "mole-rpc-autotester": "^1.0.0"
     },
     "scripts": {
-        "test": "node ./tests/autotests.js || exit 1"
+        "test": "(node ./tests/autotests.js && node ./tests/pingpongtests.js) || exit 1"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mole-rpc",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "description": "Transport agnostic spec compliant JSON RPC client and server",
     "main": "index.js",
     "directories": {

--- a/proxify.js
+++ b/proxify.js
@@ -1,21 +1,34 @@
 function proxify(moleClient) {
+    const initProxy = proxifyOwnMethod(moleClient.init.bind(moleClient));
+    const shutdownProxy = proxifyOwnMethod(moleClient.shutdown.bind(moleClient));
     const callMethodProxy = proxifyOwnMethod(moleClient.callMethod.bind(moleClient));
     const notifyProxy = proxifyOwnMethod(moleClient.notify.bind(moleClient));
+    const onProxy = proxifyOwnMethod(moleClient.on.bind(moleClient));
+    const offProxy = proxifyOwnMethod(moleClient.off.bind(moleClient));
 
     return new Proxy(moleClient, {
         get(target, methodName) {
-            if (methodName === 'notify') {
-                return notifyProxy;
-            } else if (methodName === 'callMethod') {
-                return callMethodProxy;
-            } else if (methodName === 'options.requestTimeout') {
-                return target.requestTimeout;
-            } else if (methodName === 'then') {
-                // without this you will not be able to return client from an async function.
-                // V8 will see then method and will decide that client is a promise
-                return;
-            } else {
-                return (...params) => target.callMethod.call(target, methodName, params);
+            switch (methodName) {
+                case 'init':
+                    return initProxy;
+                case 'shutdown':
+                    return shutdownProxy;
+                case 'callMethod':
+                    return callMethodProxy;
+                case 'notify':
+                    return notifyProxy;
+                case 'on':
+                    return onProxy;
+                case 'off':
+                    return offProxy;
+                case 'options.requestTimeout':
+                    return target.requestTimeout;
+                case 'then':
+                    // without this you will not be able to return client from an async function.
+                    // V8 will see then method and will decide that client is a promise
+                    return;
+                default:
+                    return (...params) => target.callMethod.call(target, methodName, params);
             }
         }
     });

--- a/tests/autotests.js
+++ b/tests/autotests.js
@@ -5,11 +5,10 @@ const MoleClientProxified = require('../MoleClientProxified');
 const MoleServer = require('../MoleServer');
 const X = require('../X');
 
-
 const TransportClient = require('./TransportClient');
 const TransportServer = require('./TransportServer');
 
-const EventEmitter = require('events');
+const EventEmitter = require('../EventEmitter');
 
 async function main() {
     const emitter = new EventEmitter();

--- a/tests/autotests.js
+++ b/tests/autotests.js
@@ -25,6 +25,8 @@ async function main() {
     });
 
     await autoTester.runAllTests();
+
+    clients.proxifiedClient.shutdown();
 }
 
 async function prepareServer(emitter) {
@@ -60,7 +62,10 @@ async function prepareClients(emitter) {
             emitter,
             inTopic: 'toClient2',
             outTopic: 'fromClient2'
-        })
+        }),
+        ping: true,
+        pingInterval: 100,
+        pingTimeout: 10
     });
 
     return { simpleClient, proxifiedClient };

--- a/tests/pingpongtests.js
+++ b/tests/pingpongtests.js
@@ -1,0 +1,74 @@
+const MoleClient = require('../MoleClient');
+const MoleServer = require('../MoleServer');
+
+const TransportClient = require('./TransportClient');
+const TransportServer = require('./TransportServer');
+
+const EventEmitter = require('../EventEmitter');
+const { sleep, assertIsTrue } = require('./utils');
+
+async function main() {
+    const emitter = new EventEmitter();
+
+    const server = await prepareServer(emitter);
+    const client = await prepareClient(emitter);
+
+    await server.run();
+
+    await testPingPong({ client, emitter });
+
+    client.shutdown();
+
+    console.log('Ping pong tests passed successfully');
+}
+
+async function testPingPong({ client, emitter }) {
+    let serverAvailable = true;
+
+    client.on(MoleClient.EVENTS.SERVER_AVAILABLE, () => {
+        serverAvailable = true;
+    });
+
+    client.on(MoleClient.EVENTS.SERVER_UNAVAILABLE, () => {
+        serverAvailable = false;
+    });
+
+    emitter.pause();
+    await sleep(100);
+
+    assertIsTrue(!serverAvailable, 'Server should be unavailable if transport doesn`t work');
+
+    emitter.resume();
+    await sleep(100);
+
+    assertIsTrue(serverAvailable, 'Server should be available if transport works');
+}
+
+async function prepareServer(emitter) {
+    return new MoleServer({
+        transports: [
+            new TransportServer({
+                emitter,
+                inTopic: 'fromClient1',
+                outTopic: 'toClient1'
+            })
+        ]
+    });
+}
+
+async function prepareClient(emitter) {
+    const simpleClient = new MoleClient({
+        transport: new TransportClient({
+            emitter,
+            inTopic: 'toClient1',
+            outTopic: 'fromClient1'
+        }),
+        ping: true,
+        pingInterval: 50,
+        pingTimeout: 10
+    });
+
+    return simpleClient;
+}
+
+main().then(console.log, console.error);

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,14 @@
+function sleep(delay) {
+    return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+function assertIsTrue(value, errorMessage = 'value should equal true') {
+    if (value !== true) {
+        throw new Error(`Assert failed: ${errorMessage}`);
+    }
+}
+
+module.exports = {
+    sleep,
+    assertIsTrue
+};


### PR DESCRIPTION
Problem: we need to handle server availability for some transports (ws,mqtt) that don't support transport-level pings. WS actually support pings, but this API is not available in browser. 

Solution: Create app-level ping/pong mechanism via exposing internal methods.

There is also an idea to return SERVICE_UNAVAILABLE error for callMethod until our ping succeeds.
In this case, it also requires implementing some Fast-Recovery approach to increase ping frequency in case of error.
But it seems a bit over-engineering for this task. 

Autotests passed
New tests added