### PR TITLE
Add ability to provide timeout for a single callMethod exec

### DIFF
--- a/MoleClient.js
+++ b/MoleClient.js
@@ -21,12 +21,12 @@ class MoleClient {
         await this._init();
     }
 
-    async callMethod(method, params) {
+    async callMethod(method, params, options = {}) {
         await this._init();
 
         const request = this._makeRequestObject({ method, params });
 
-        return this._sendRequest({ object: request, id: request.id });
+        return this._sendRequest({ object: request, id: request.id, timeout: options.timeout || this.requestTimeout });
     }
 
     async notify(method, params) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "mole-rpc",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mole-rpc",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "devDependencies": {
-                "mole-rpc-autotester": "^1.0.0"
+                "mole-rpc-autotester": "^1.1.0"
             },
             "engines": {
                 "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mole-rpc",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mole-rpc",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "license": "MIT",
             "devDependencies": {
                 "mole-rpc-autotester": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mole-rpc",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "description": "Transport agnostic spec compliant JSON RPC client and server",
     "main": "index.js",
     "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mole-rpc",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Transport agnostic spec compliant JSON RPC client and server",
     "main": "index.js",
     "directories": {
@@ -11,7 +11,7 @@
         "node": ">=10.0.0"
     },
     "devDependencies": {
-        "mole-rpc-autotester": "^1.0.0"
+        "mole-rpc-autotester": "^1.1.0"
     },
     "scripts": {
         "test": "node ./tests/autotests.js || exit 1"


### PR DESCRIPTION
## Changes

- Added `options` param into MoleClient.callMethod to pass `timeout`